### PR TITLE
test: add spec tests for two gaps found via mutation testing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         run: make build
 
       - name: Run Trivy security scan
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'jonbaldie/varnish:latest'
           format: 'sarif'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation
+.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -22,7 +22,7 @@ test-makefile-shell:
 
 test: build test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace
 
-test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation
+test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached
 
 test-existence:
 	@echo "=== Test: File existence ==="
@@ -533,6 +533,99 @@ test-hostile-set-cookie-isolation:
 	fi; \
 	echo "OK: Bob response stayed uncached and isolated from alice's Set-Cookie response"; \
 	echo "=== Test: Hostile Set-Cookie responses are not shared across clients PASSED ==="
+
+test-5xx-not-cached:
+	@echo "=== Test: Backend 5xx responses are not served from cache ==="
+	@set -euo pipefail; \
+	lockdir="/tmp/varnish-5xx-test-8082.lock"; \
+	acquired=0; \
+	while [ $$acquired -eq 0 ]; do \
+		if mkdir "$$lockdir" 2>/dev/null; then \
+			acquired=1; \
+		else \
+			sleep 1; \
+		fi; \
+	done; \
+	project="varnish-5xx-test-$$$$"; \
+	trap "rm -rf $$lockdir; docker compose -p $$project -f docker-compose.5xx-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	docker compose -p $$project -f docker-compose.5xx-test.yml up -d --build; \
+	echo "Waiting for services to be ready (includes backend probe warm-up)..."; \
+	timeout=60; \
+	while [ $$timeout -gt 0 ]; do \
+		if curl -sf --max-time 5 http://localhost:8082/ready >/dev/null 2>&1; then \
+			echo "OK: Services are ready"; \
+			break; \
+		fi; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ $$timeout -eq 0 ]; then \
+		echo "FAIL: Services did not become ready within 60s"; \
+		docker compose -p $$project -f docker-compose.5xx-test.yml logs; \
+		exit 1; \
+	fi; \
+	url="http://localhost:8082/error"; \
+	echo "Purging any existing cached error response..."; \
+	status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X PURGE "$$url"); \
+	if [ "$$status" != "200" ]; then \
+		echo "FAIL: Expected PURGE HTTP 200, got $$status"; \
+		exit 1; \
+	fi; \
+	tmpdir=$$(mktemp -d); \
+	trap "rm -rf $$tmpdir $$lockdir; docker compose -p $$project -f docker-compose.5xx-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	resp1_headers="$$tmpdir/resp1.headers"; \
+	resp1_body="$$tmpdir/resp1.body"; \
+	resp2_headers="$$tmpdir/resp2.headers"; \
+	resp2_body="$$tmpdir/resp2.body"; \
+	echo "Requesting /error (first request)..."; \
+	curl -sS --max-time 10 -D "$$resp1_headers" -o "$$resp1_body" "$$url" || true; \
+	if ! grep -q '^route=error$$' "$$resp1_body"; then \
+		echo "FAIL: Expected first response body to contain route=error"; \
+		cat "$$resp1_body"; \
+		exit 1; \
+	fi; \
+	if ! grep -qi '^X-Cache: MISS' "$$resp1_headers"; then \
+		echo "FAIL: Expected first error response X-Cache: MISS"; \
+		cat "$$resp1_headers"; \
+		exit 1; \
+	fi; \
+	req1_id=$$(grep -i '^X-Backend-Request-Id:' "$$resp1_headers" | tr -d '\r' | cut -d' ' -f2); \
+	if [ -z "$$req1_id" ]; then \
+		echo "FAIL: Expected first response to include X-Backend-Request-Id"; \
+		cat "$$resp1_headers"; \
+		exit 1; \
+	fi; \
+	echo "OK: First error response was a MISS from origin (request_id=$$req1_id)"; \
+	echo "Requesting /error again immediately (second request)..."; \
+	curl -sS --max-time 10 -D "$$resp2_headers" -o "$$resp2_body" "$$url" || true; \
+	if ! grep -q '^route=error$$' "$$resp2_body"; then \
+		echo "FAIL: Expected second response body to contain route=error"; \
+		cat "$$resp2_body"; \
+		exit 1; \
+	fi; \
+	if ! grep -qi '^X-Cache: MISS' "$$resp2_headers"; then \
+		echo "FAIL: Expected second error response X-Cache: MISS (error must not be cached)"; \
+		cat "$$resp2_headers"; \
+		exit 1; \
+	fi; \
+	req2_id=$$(grep -i '^X-Backend-Request-Id:' "$$resp2_headers" | tr -d '\r' | cut -d' ' -f2); \
+	if [ -z "$$req2_id" ]; then \
+		echo "FAIL: Expected second response to include X-Backend-Request-Id"; \
+		cat "$$resp2_headers"; \
+		exit 1; \
+	fi; \
+	if [ "$$req1_id" = "$$req2_id" ]; then \
+		echo "FAIL: Both requests returned the same X-Backend-Request-Id ($$req1_id)"; \
+		echo "      Error response was served from cache rather than fetched from origin"; \
+		echo "--- request 1 headers ---"; \
+		cat "$$resp1_headers"; \
+		echo "--- request 2 headers ---"; \
+		cat "$$resp2_headers"; \
+		exit 1; \
+	fi; \
+	echo "OK: Second error response was also a MISS from origin (request_id=$$req2_id)"; \
+	echo "OK: Distinct backend request IDs confirm origin was hit twice, error was not cached"; \
+	echo "=== Test: Backend 5xx responses are not served from cache PASSED ==="
 
 test-perf:
 	@echo "=== Test: Performance and caching effectiveness ==="

--- a/docker-compose.5xx-test.yml
+++ b/docker-compose.5xx-test.yml
@@ -1,0 +1,29 @@
+services:
+  varnish:
+    build: .
+    image: jonbaldie/varnish
+    ports:
+      - "8082:80"
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    depends_on:
+      web:
+        condition: service_healthy
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+
+  web:
+    build:
+      context: ./test/hostile-backend
+    environment:
+      PORT: "80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 1s
+    restart: unless-stopped

--- a/test/hostile-backend/server.py
+++ b/test/hostile-backend/server.py
@@ -57,9 +57,21 @@ class Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         cookie_header = self.headers.get("Cookie")
 
-        # Health check endpoint for container readiness probes
-        if self.path == "/ready":
+        # Health check endpoints for container readiness probes.
+        # "/" is used by the main VCL backend probe; "/ready" by the hostile
+        # compose healthcheck. Both must return 200 so Varnish marks the
+        # backend as healthy before any test assertions run.
+        if self.path in ("/", "/ready"):
             self.respond(200, "ready=ok\n")
+            return
+
+        # Proves 5xx backend responses are not served from cache.
+        # Test assertion: two consecutive requests must both produce
+        # X-Cache: MISS and distinct X-Backend-Request-Id values,
+        # proving Varnish hit origin each time rather than caching the error.
+        if self.path == "/error":
+            body = "route=error\n"
+            self.respond(500, body)
             return
 
         # Proves Varnish strips cookies from cacheable static assets.


### PR DESCRIPTION
## What

Two missing spec-level tests found by running a language-agnostic mutation testing harness against `default.vcl`.

The harness worked as follows: patch the file, run build + test commands, check exit codes. No language-specific tooling — the mutations were text-level transforms on VCL, the test oracle was `make test-e2e-hard`.

---

## Gap 1 — cookie stripping for static assets

**Spec:** static assets must never carry the client's `Cookie` header to origin, regardless of what the client sends.

**Mutation tested (M1):** remove the `unset req.http.Cookie` block from `vcl_recv`.

**Finding:** this mutation *survived* `make test`. The base test suite (nginx happy-path) has no way to observe what headers reach origin, so it cannot assert this spec.

**Status:** already covered by `test-hostile-static-cookie` in `test-e2e-hard`, which runs in CI. No new test needed. Documented here for traceability.

---

## Gap 2 — backend 5xx responses must not be positively cached

**Spec:** when the backend returns a 5xx error, Varnish must not serve that response from cache on subsequent requests. Every request to a broken URL must hit origin fresh.

**Mutation tested (M6):** change `beresp.ttl = 0s` to `beresp.ttl = 60s` in the 5xx handler inside `vcl_backend_response`.

**Finding:** this mutation *survived both* `make test` and `make test-e2e-hard`. Nothing in the suite exercised the 5xx code path with a TTL assertion.

**Fix:** new `test-5xx-not-cached` target added to `test-e2e-hard`.

---

## How the new test works

- `docker-compose.5xx-test.yml` spins up the main Varnish image (volume-mounting the production `default.vcl`) with the hostile backend standing in as the `web` service on port 8082.
- The hostile backend gains a `/error` endpoint that always returns 500 with a unique `X-Backend-Request-Id` per origin hit.
- The hostile backend also handles `GET /` (required by the main VCL's backend health probe).
- The test purges `/error`, makes two consecutive requests, and asserts:
  - both return `X-Cache: MISS` (error not cached)
  - both have distinct `X-Backend-Request-Id` values (origin hit each time, not cache)

This test kills M6 cleanly and passes against the unmodified VCL.