### PR TITLE
ci: push image to Docker Hub on merge to master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,3 +37,14 @@ jobs:
 
       - name: Run hostile E2E tests
         run: make test-e2e-hard
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push to Docker Hub
+        if: github.event_name == 'push'
+        run: docker push jonbaldie/varnish:latest


### PR DESCRIPTION
Adds login and push steps at the end of the build-and-test job, gated on `github.event_name == 'push'` so they only run on merges to master, not on PRs.

Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to be set as repository secrets.