### PR TITLE
test: close three mutation-testing gaps (purge ACL, POST caching, grace-stale)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached
+.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -22,7 +22,7 @@ test-makefile-shell:
 
 test: build test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace
 
-test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached
+test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 test-existence:
 	@echo "=== Test: File existence ==="
@@ -626,6 +626,189 @@ test-5xx-not-cached:
 	echo "OK: Second error response was also a MISS from origin (request_id=$$req2_id)"; \
 	echo "OK: Distinct backend request IDs confirm origin was hit twice, error was not cached"; \
 	echo "=== Test: Backend 5xx responses are not served from cache PASSED ==="
+
+test-purge-unauthorized:
+	@echo "=== Test: Unauthorized PURGE from outside ACL returns 405 ==="
+	@set -euo pipefail; \
+	lockdir="/tmp/varnish-purge-acl-test-8085.lock"; \
+	acquired=0; \
+	while [ $$acquired -eq 0 ]; do \
+		if mkdir "$$lockdir" 2>/dev/null; then \
+			acquired=1; \
+		else \
+			sleep 1; \
+		fi; \
+	done; \
+	project="varnish-purge-acl-$$$$"; \
+	trap "rm -rf $$lockdir; docker compose -p $$project -f docker-compose.purge-acl-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	docker compose -p $$project -f docker-compose.purge-acl-test.yml up -d --build; \
+	echo "Waiting for services to be ready..."; \
+	timeout=60; \
+	while [ $$timeout -gt 0 ]; do \
+		if curl -sf --max-time 5 http://localhost:8085/ready >/dev/null 2>&1; then \
+			echo "OK: Services are ready"; \
+			break; \
+		fi; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ $$timeout -eq 0 ]; then \
+		echo "FAIL: Services did not become ready within 60s"; \
+		docker compose -p $$project -f docker-compose.purge-acl-test.yml logs; \
+		exit 1; \
+	fi; \
+	echo "Verifying authorized PURGE from host (IP in ACL) succeeds..."; \
+	status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 -X PURGE http://localhost:8085/); \
+	if [ "$$status" != "200" ]; then \
+		echo "FAIL: Expected authorized PURGE to return 200, got $$status"; \
+		exit 1; \
+	fi; \
+	echo "OK: Authorized PURGE returns 200"; \
+	echo "Testing unauthorized PURGE from 203.0.113.100 (outside ACL)..."; \
+	net="$$(docker network ls --filter "name=$${project}" --format '{{.Name}}' | grep "_external$$")"; \
+	if [ -z "$$net" ]; then \
+		echo "FAIL: Could not find external test network for project $$project"; \
+		docker network ls --filter "name=$${project}"; \
+		exit 1; \
+	fi; \
+	status=$$(docker run --rm \
+		--network "$$net" \
+		--ip 203.0.113.100 \
+		alpine \
+		sh -c "apk add -q curl && curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X PURGE http://203.0.113.2/"); \
+	if [ "$$status" != "405" ]; then \
+		echo "FAIL: Expected 405 for unauthorized PURGE from 203.0.113.100, got $$status"; \
+		exit 1; \
+	fi; \
+	echo "OK: Unauthorized PURGE from 203.0.113.100 returns 405"; \
+	echo "=== Test: Unauthorized PURGE from outside ACL returns 405 PASSED ==="
+
+test-post-not-cached:
+	@echo "=== Test: POST to a cached URL bypasses cache and hits origin ==="
+	@set -euo pipefail; \
+	lockdir="/tmp/varnish-post-test-8084.lock"; \
+	acquired=0; \
+	while [ $$acquired -eq 0 ]; do \
+		if mkdir "$$lockdir" 2>/dev/null; then \
+			acquired=1; \
+		else \
+			sleep 1; \
+		fi; \
+	done; \
+	project="varnish-post-test-$$$$"; \
+	trap "rm -rf $$lockdir; docker compose -p $$project -f docker-compose.post-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	docker compose -p $$project -f docker-compose.post-test.yml up -d --build; \
+	echo "Waiting for services to be ready..."; \
+	timeout=60; \
+	while [ $$timeout -gt 0 ]; do \
+		if curl -sf --max-time 10 http://localhost:8084/ready >/dev/null 2>&1; then \
+			echo "OK: Services are ready"; \
+			break; \
+		fi; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ $$timeout -eq 0 ]; then \
+		echo "FAIL: Services did not become ready within 60s"; \
+		docker compose -p $$project -f docker-compose.post-test.yml logs; \
+		exit 1; \
+	fi; \
+	url="http://localhost:8084/static/app.css"; \
+	echo "Purging any existing cached asset..."; \
+	curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X PURGE "$$url" >/dev/null; \
+	tmpdir=$$(mktemp -d); \
+	trap "rm -rf $$tmpdir $$lockdir; docker compose -p $$project -f docker-compose.post-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	echo "Priming cache with GET (first request, expect MISS)..."; \
+	cache=$$(curl -sI --max-time 10 "$$url" | grep -i x-cache); \
+	if ! echo "$$cache" | grep -qi MISS; then \
+		echo "FAIL: Expected X-Cache MISS on first GET, got: $$cache"; \
+		exit 1; \
+	fi; \
+	echo "Confirming GET is cached (second request, expect HIT)..."; \
+	cache=$$(curl -sI --max-time 10 "$$url" | grep -i x-cache); \
+	if ! echo "$$cache" | grep -qi HIT; then \
+		echo "FAIL: Expected X-Cache HIT on second GET, got: $$cache"; \
+		exit 1; \
+	fi; \
+	echo "OK: GET response is cached"; \
+	echo "Sending POST to the same cached URL..."; \
+	post_headers="$$tmpdir/post.headers"; \
+	post_body="$$tmpdir/post.body"; \
+	curl -sS --max-time 10 -X POST -D "$$post_headers" -o "$$post_body" "$$url"; \
+	post_cache=$$(grep -i x-cache "$$post_headers" || true); \
+	if ! echo "$$post_cache" | grep -qi MISS; then \
+		echo "FAIL: POST returned cached GET response (X-Cache: HIT) — non-GET methods must bypass cache"; \
+		echo "--- POST response headers ---"; \
+		cat "$$post_headers"; \
+		exit 1; \
+	fi; \
+	post_request_id=$$(grep -i '^X-Backend-Request-Id:' "$$post_headers" | tr -d '\r' | cut -d' ' -f2); \
+	if [ -z "$$post_request_id" ]; then \
+		echo "FAIL: POST response missing X-Backend-Request-Id — did not reach origin"; \
+		cat "$$post_headers"; \
+		exit 1; \
+	fi; \
+	echo "OK: POST bypassed cache, reached origin (request_id=$$post_request_id, X-Cache: MISS)"; \
+	echo "=== Test: POST to a cached URL bypasses cache and hits origin PASSED ==="
+
+test-grace-stale:
+	@echo "=== Test: Grace serves stale content after TTL expires with backend down ==="
+	@set -euo pipefail; \
+	lockdir="/tmp/varnish-grace-test-8083.lock"; \
+	acquired=0; \
+	while [ $$acquired -eq 0 ]; do \
+		if mkdir "$$lockdir" 2>/dev/null; then \
+			acquired=1; \
+		else \
+			sleep 1; \
+		fi; \
+	done; \
+	project="varnish-grace-stale-$$$$"; \
+	trap "rm -rf $$lockdir; docker compose -p $$project -f docker-compose.grace-test.yml down --remove-orphans >/dev/null 2>&1" EXIT; \
+	docker compose -p $$project -f docker-compose.grace-test.yml up -d --build; \
+	echo "Waiting for services to be ready..."; \
+	timeout=60; \
+	while [ $$timeout -gt 0 ]; do \
+		if curl -sf --max-time 5 http://localhost:8083/ready >/dev/null 2>&1; then \
+			echo "OK: Services are ready"; \
+			break; \
+		fi; \
+		sleep 2; \
+		timeout=$$((timeout - 2)); \
+	done; \
+	if [ $$timeout -eq 0 ]; then \
+		echo "FAIL: Services did not become ready within 60s"; \
+		docker compose -p $$project -f docker-compose.grace-test.yml logs; \
+		exit 1; \
+	fi; \
+	url="http://localhost:8083/short-cache"; \
+	echo "Priming cache (first request, expect MISS)..."; \
+	cache=$$(curl -sI --max-time 10 "$$url" | grep -i x-cache); \
+	if ! echo "$$cache" | grep -qi MISS; then \
+		echo "FAIL: Expected X-Cache MISS on first request, got: $$cache"; \
+		exit 1; \
+	fi; \
+	echo "Confirming object is cached (second request, expect HIT)..."; \
+	cache=$$(curl -sI --max-time 10 "$$url" | grep -i x-cache); \
+	if ! echo "$$cache" | grep -qi HIT; then \
+		echo "FAIL: Expected X-Cache HIT on second request, got: $$cache"; \
+		exit 1; \
+	fi; \
+	echo "OK: Object cached with 10s TTL and 1h grace"; \
+	echo "Stopping backend..."; \
+	docker compose -p $$project -f docker-compose.grace-test.yml stop web; \
+	echo "Waiting 22s for TTL to expire (10s) and backend to be marked sick (~15s)..."; \
+	sleep 22; \
+	echo "Requesting stale object with backend down..."; \
+	status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$$url"); \
+	if [ "$$status" != "200" ]; then \
+		echo "FAIL: Expected HTTP 200 from grace (stale), got $$status"; \
+		echo "      VCL beresp.grace = 1h means stale content must be served"; \
+		echo "      for up to 1 hour after TTL expires while backend is down"; \
+		exit 1; \
+	fi; \
+	echo "OK: HTTP 200 served from grace after TTL expired and backend is down"; \
+	echo "=== Test: Grace serves stale content after TTL expires with backend down PASSED ==="
 
 test-perf:
 	@echo "=== Test: Performance and caching effectiveness ==="

--- a/docker-compose.grace-test.yml
+++ b/docker-compose.grace-test.yml
@@ -1,0 +1,29 @@
+services:
+  varnish:
+    build: .
+    image: jonbaldie/varnish
+    ports:
+      - "8083:80"
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    depends_on:
+      web:
+        condition: service_healthy
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+
+  web:
+    build:
+      context: ./test/hostile-backend
+    environment:
+      PORT: "80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 1s
+    restart: unless-stopped

--- a/docker-compose.post-test.yml
+++ b/docker-compose.post-test.yml
@@ -1,0 +1,29 @@
+services:
+  varnish:
+    build: .
+    image: jonbaldie/varnish
+    ports:
+      - "8084:80"
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    depends_on:
+      web:
+        condition: service_healthy
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+
+  web:
+    build:
+      context: ./test/hostile-backend
+    environment:
+      PORT: "80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 1s
+    restart: unless-stopped

--- a/docker-compose.purge-acl-test.yml
+++ b/docker-compose.purge-acl-test.yml
@@ -1,0 +1,45 @@
+services:
+  varnish:
+    build: .
+    image: jonbaldie/varnish
+    ports:
+      - "8085:80"
+    volumes:
+      - ./default.vcl:/etc/varnish/default.vcl:ro
+    depends_on:
+      web:
+        condition: service_healthy
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    networks:
+      backend:
+      external:
+        ipv4_address: 203.0.113.2
+
+  web:
+    build:
+      context: ./test/hostile-backend
+    environment:
+      PORT: "80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/ready"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 1s
+    restart: unless-stopped
+    networks:
+      - backend
+
+networks:
+  backend:
+    driver: bridge
+  external:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 203.0.113.0/24

--- a/test/hostile-backend/server.py
+++ b/test/hostile-backend/server.py
@@ -74,6 +74,21 @@ class Handler(BaseHTTPRequestHandler):
             self.respond(500, body)
             return
 
+        # Proves grace period serves stale content when backend is down.
+        # Sets a short TTL (10s) so the test can wait past expiry without
+        # waiting for the 120s Varnish default TTL.
+        # Test assertion: after TTL expires AND backend is sick, a request
+        # must still return 200 because VCL sets beresp.grace = 1h for
+        # non-static content.
+        if self.path == "/short-cache":
+            body = "route=short-cache\n"
+            self.respond(
+                200,
+                body,
+                extra_headers={"Cache-Control": "public, max-age=10"},
+            )
+            return
+
         # Proves Varnish strips cookies from cacheable static assets.
         # Test assertion: request with Cookie should produce response body
         # containing "cookie=none", proving the Cookie header was removed
@@ -114,6 +129,16 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         self.respond(404, "route=not-found\n")
+
+    def do_POST(self) -> None:
+        """Handle POST requests identically to GET.
+
+        POST requests must never be served from Varnish's cache.  This handler
+        lets the test verify that a POST to a previously-cached URL actually
+        reaches the origin (producing a distinct X-Backend-Request-Id) rather
+        than being served silently from the GET cache.
+        """
+        self.do_GET()
 
     def log_message(self, format: str, *args) -> None:
         return


### PR DESCRIPTION
## What

Manual mutation testing found three escaped mutants — mutations to `default.vcl` and `Dockerfile` that changed observable user-facing behaviour but were invisible to the existing test suite.

## Mutations & gaps closed

### M1b — Remove purge ACL entirely (`test-purge-unauthorized`)
**Mutation:** delete the `acl purge { … }` block and the `return (synth(405, …))` guard so any IP can purge the cache.  
**Why it escaped:** `test-purge` only tests that an authorised request (from localhost, which is in the ACL) returns 200. No test ever sent a PURGE from an IP outside the ACL.  
**Fix:** new `docker-compose.purge-acl-test.yml` with a dual-network layout. The test client container gets IP `203.0.113.100` (subnet `203.0.113.0/24`, reserved TEST-NET-3, not in any ACL CIDR) and Varnish has a static IP on that network. Confirms both directions: authorised PURGE → 200, unauthorised PURGE → 405.

### M12 — Remove `return (pass)` for non-GET/HEAD (`test-post-not-cached`)
**Mutation:** delete the guard that passes POST/PUT/DELETE through to origin. A cookieless POST to a cached URL falls through to `return (hash)`, receives the cached GET response, and returns X-Cache: HIT.  
**Why it escaped:** no test ever sent a POST request.  
**Fix:** `docker-compose.post-test.yml` mounts the main `default.vcl` (the hostile-overlay compose has its own VCL and would have hidden the mutation). Primes cache with GET, then sends POST to the same URL, asserts X-Cache: MISS and a distinct `X-Backend-Request-Id` proving origin was reached. Also adds `do_POST = do_GET` to the hostile backend so POST requests return a clean, traceable response rather than a Python 501.

### M6 — Set `beresp.grace = 0s` for non-static content (`test-grace-stale`)
**Mutation:** replace `beresp.grace = 1h` with `beresp.grace = 0s` in the non-static branch of `vcl_backend_response`.  
**Why it escaped:** `test-grace` stops the backend and waits 18s, but nginx's index page carries no Cache-Control so Varnish uses its 120s default TTL. The object was still within TTL at check time — grace was never consulted, so grace = 0s made no difference.  
**Fix:** adds a `/short-cache` endpoint to the hostile backend (`Cache-Control: public, max-age=10`). `test-grace-stale` stops the backend then waits 22s: past the 10s TTL expiry and past the ~15s needed for the probe window to mark the backend sick. With `grace = 1h` → 200; with `grace = 0s` → 503.

## What was deliberately not written

- HEALTHCHECK presence — Docker metadata, not observable behaviour
- EXPOSE port — Docker metadata
- Varnish version pin — build quality, not behaviour

## Verification

All existing tests pass unchanged. All three new tests confirm correct behaviour on the unmodified codebase and fail on their respective mutations.