### PR TITLE
Deepen the runtime start interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN chown -R varnish:varnish /etc/varnish /var/lib/varnish
 VOLUME ["/var/lib/varnish", "/etc/varnish"]
 EXPOSE 80
 
-ENV VARNISH_START="/usr/sbin/varnishd -F -f /etc/varnish/default.vcl -a 0.0.0.0:80 -s malloc,1g"
+ENV VARNISH_LISTEN=0.0.0.0:80 \
+    VARNISH_VCL=/etc/varnish/default.vcl \
+    VARNISH_STORAGE=malloc,1g
+ENV VARNISH_EXTRA_ARGS=""
 ADD start.sh /start.sh
 RUN chown varnish:varnish /start.sh && chmod +x /start.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -20,7 +20,7 @@ test-makefile-shell:
 	@set -euo pipefail; echo "OK: pipefail supported"
 	@echo "=== Test: Makefile shell compatibility PASSED ==="
 
-test: build test-existence test-vcl-compile test-smoke test-integration test-security test-purge test-grace
+test: build test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace
 
 test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
@@ -53,26 +53,91 @@ test-vcl-compile:
 test-smoke:
 	@echo "=== Test: Smoke test ==="
 	@set -euo pipefail; \
-	name="$(CONTAINER_PREFIX)-smoke-$$(openssl rand -hex 4)"; \
-	docker run -d --name $$name $(IMAGE) >/dev/null; \
-	trap "docker rm -f $$name >/dev/null 2>&1" EXIT; \
-	echo "Waiting for varnishd to start..."; \
-	timeout=30; \
-	while [ $$timeout -gt 0 ]; do \
-		if docker exec $$name pidof varnishd >/dev/null 2>&1; then \
-			echo "OK: varnishd is running"; \
-			break; \
+		name="$(CONTAINER_PREFIX)-smoke-$$(openssl rand -hex 4)"; \
+		host_port=18080; \
+		docker run -d --name $$name -p $$host_port:80 $(IMAGE) >/dev/null; \
+		trap "docker rm -f $$name >/dev/null 2>&1" EXIT; \
+		echo "Waiting for varnishd to serve HTTP on $$host_port..."; \
+		timeout=30; \
+		status="000"; \
+		while [ $$timeout -gt 0 ]; do \
+			status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:$$host_port || true); \
+			if [ "$$status" != "000" ]; then \
+				echo "OK: varnishd served HTTP $$status on port $$host_port"; \
+				break; \
+			fi; \
+			sleep 1; \
+			timeout=$$((timeout - 1)); \
+		done; \
+		if [ "$$status" = "000" ]; then \
+			echo "FAIL: varnishd did not serve HTTP within 30s"; \
+			docker logs $$name; \
+			exit 1; \
 		fi; \
-		sleep 1; \
-		timeout=$$((timeout - 1)); \
-	done; \
-	if [ $$timeout -eq 0 ]; then \
-		echo "FAIL: varnishd did not start within 30s"; \
-		docker logs $$name; \
-		exit 1; \
-	fi; \
-	docker exec $$name varnishadm status; \
-	echo "=== Test: Smoke test PASSED ==="
+		docker exec $$name varnishadm status >/dev/null; \
+		echo "OK: varnishadm status responded"; \
+		echo "=== Test: Smoke test PASSED ==="
+
+test-smoke-runtime-interface:
+	@echo "=== Test: Runtime start interface ==="
+	@set -euo pipefail; \
+		name="$(CONTAINER_PREFIX)-runtime-$$(openssl rand -hex 4)"; \
+		host_port=18081; \
+		tmpdir=$$(mktemp -d); \
+		trap "docker rm -f $$name >/dev/null 2>&1; rm -rf $$tmpdir" EXIT; \
+		docker run -d --name $$name \
+			-e VARNISH_LISTEN=0.0.0.0:8080 \
+			-p $$host_port:8080 \
+			$(IMAGE) >/dev/null; \
+		echo "Waiting for overridden HTTP listener on $$host_port..."; \
+		timeout=30; \
+		status="000"; \
+		while [ $$timeout -gt 0 ]; do \
+			status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:$$host_port || true); \
+			if [ "$$status" != "000" ]; then \
+				echo "OK: runtime override served HTTP $$status on port $$host_port"; \
+				break; \
+			fi; \
+			sleep 1; \
+			timeout=$$((timeout - 1)); \
+		done; \
+		if [ "$$status" = "000" ]; then \
+			echo "FAIL: runtime override did not expose HTTP on port $$host_port"; \
+			docker logs $$name; \
+			exit 1; \
+		fi; \
+		docker rm -f $$name >/dev/null; \
+		log_file="$$tmpdir/invalid-listen.log"; \
+		set +e; \
+		docker run --rm -e VARNISH_LISTEN=invalid $(IMAGE) >"$$log_file" 2>&1 & \
+		pid=$$!; \
+		for _ in 1 2 3 4 5; do \
+			if ! kill -0 $$pid >/dev/null 2>&1; then \
+				break; \
+			fi; \
+			sleep 1; \
+		done; \
+		if kill -0 $$pid >/dev/null 2>&1; then \
+			kill $$pid >/dev/null 2>&1 || true; \
+			wait $$pid >/dev/null 2>&1 || true; \
+			status=124; \
+		else \
+			wait $$pid; \
+			status=$$?; \
+		fi; \
+		set -e; \
+		if [ $$status -eq 0 ] || [ $$status -eq 124 ]; then \
+			echo "FAIL: invalid VARNISH_LISTEN should fail fast"; \
+			cat "$$log_file"; \
+			exit 1; \
+		fi; \
+		if ! grep -q "Invalid VARNISH_LISTEN" "$$log_file"; then \
+			echo "FAIL: invalid VARNISH_LISTEN should fail clearly"; \
+			cat "$$log_file"; \
+			exit 1; \
+		fi; \
+		echo "OK: invalid listen configuration failed clearly"; \
+		echo "=== Test: Runtime start interface PASSED ==="
 
 test-integration:
 	@echo "=== Test: Integration test ==="

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Expose Varnish on port 80 and point it at your web server via a `vcl` config fil
 
 For this image, `ADD` your `default.vcl` into `/etc/varnish/` inside the container. Using Docker Compose with mounted volumes means you can edit the config without rebuilding.
 
+## Runtime Configuration
+
+The container starts `varnishd` from named runtime values instead of a single baked command string.
+
+- `VARNISH_LISTEN` defaults to `0.0.0.0:80`
+- `VARNISH_VCL` defaults to `/etc/varnish/default.vcl`
+- `VARNISH_STORAGE` defaults to `malloc,1g`
+- `VARNISH_EXTRA_ARGS` appends extra `varnishd` flags when you need a small escape hatch
+
+For advanced cases, `VARNISH_START` still works as a full-command override, but it cannot be combined with the narrower `VARNISH_*` settings.
+
 ## VCL Configuration
 
 `default.vcl` is the single source of truth for Varnish config. It includes:

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,54 @@
 #!/bin/bash
 
-${VARNISH_START}
+set -euo pipefail
+
+fail() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+if [ -n "${VARNISH_START:-}" ]; then
+	if [ -n "${VARNISH_LISTEN:-}" ] || [ -n "${VARNISH_VCL:-}" ] || [ -n "${VARNISH_STORAGE:-}" ] || [ -n "${VARNISH_EXTRA_ARGS:-}" ]; then
+		fail "VARNISH_START cannot be combined with VARNISH_LISTEN, VARNISH_VCL, VARNISH_STORAGE, or VARNISH_EXTRA_ARGS"
+	fi
+
+	exec /bin/bash -lc "${VARNISH_START}"
+fi
+
+listen="${VARNISH_LISTEN:-0.0.0.0:80}"
+vcl_path="${VARNISH_VCL:-/etc/varnish/default.vcl}"
+storage="${VARNISH_STORAGE:-malloc,1g}"
+extra_args="${VARNISH_EXTRA_ARGS:-}"
+
+case "${listen}" in
+	*:* ) ;;
+	* )
+		fail "Invalid VARNISH_LISTEN '${listen}'; expected host:port"
+		;;
+esac
+
+if [ ! -f "${vcl_path}" ]; then
+	fail "Invalid VARNISH_VCL '${vcl_path}'; file does not exist"
+fi
+
+case "${storage}" in
+	*,* ) ;;
+	* )
+		fail "Invalid VARNISH_STORAGE '${storage}'; expected backend,size"
+		;;
+esac
+
+args=(
+	/usr/sbin/varnishd
+	-F
+	-f "${vcl_path}"
+	-a "${listen}"
+	-s "${storage}"
+)
+
+if [ -n "${extra_args}" ]; then
+	read -r -a extra_words <<< "${extra_args}"
+	args+=("${extra_words[@]}")
+fi
+
+exec "${args[@]}"


### PR DESCRIPTION
## Summary
- replace the baked  default with named runtime settings in 
- validate runtime inputs early and keep  as a legacy full-command escape hatch
- add smoke coverage for default startup and one overridden listen address using the built image

## Testing
- make test
- make test-e2e-hard

Closes #20
Closes #21