### PR TITLE
Introduce backend configuration interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:bookworm-slim
 LABEL maintainer="Jonathan Baldie <jon@jonbaldie.com>"
 
-ADD default.vcl default.vcl
+ADD default.vcl.template default.vcl.template
 ADD cache-policy.vcl cache-policy.vcl
+ADD render-vcl.sh render-vcl.sh
 ADD install.sh install.sh
-RUN chmod +x install.sh && sh ./install.sh && rm install.sh default.vcl cache-policy.vcl
+RUN chmod +x install.sh render-vcl.sh && sh ./install.sh && rm install.sh default.vcl.template cache-policy.vcl render-vcl.sh
 RUN chown -R varnish:varnish /etc/varnish /var/lib/varnish
 
 VOLUME ["/var/lib/varnish", "/etc/varnish"]

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,20 @@ test-vcl-compile:
 	@echo "=== Test: VCL compilation ==="
 	@set -euo pipefail; \
 	name="$(CONTAINER_PREFIX)-emb-$$(openssl rand -hex 4)"; \
-	docker run --rm --name $$name $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null; \
+	docker run --rm --name $$name $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null 2>&1; \
 	echo "OK: Embedded VCL compiles"; \
+	name="$(CONTAINER_PREFIX)-emb-config-$$(openssl rand -hex 4)"; \
+	docker run --rm --name $$name \
+		-e VARNISH_BACKEND_HOST=localhost \
+		-e VARNISH_BACKEND_PORT=9090 \
+		-e VARNISH_BACKEND_PROBE_PATH=/healthz \
+		$(IMAGE) /bin/bash -lc '/usr/local/bin/render-vcl /etc/varnish/default.vcl.template /tmp/configured.vcl && grep -q "\\.host = \"localhost\";" /tmp/configured.vcl && grep -q "\\.port = \"9090\";" /tmp/configured.vcl && grep -q "\\.url = \"/healthz\";" /tmp/configured.vcl && /usr/sbin/varnishd -C -f /tmp/configured.vcl >/dev/null 2>&1'; \
+	echo "OK: Embedded VCL compiles with configured backend output"; \
 	name="$(CONTAINER_PREFIX)-repo-$$(openssl rand -hex 4)"; \
-	docker run --rm --name $$name --add-host web:127.0.0.1 -v $$(pwd)/default.vcl:/etc/varnish/default.vcl:ro -v $$(pwd)/cache-policy.vcl:/etc/varnish/cache-policy.vcl:ro $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null; \
+	docker run --rm --name $$name --add-host web:127.0.0.1 -v $$(pwd)/default.vcl:/etc/varnish/default.vcl:ro -v $$(pwd)/cache-policy.vcl:/etc/varnish/cache-policy.vcl:ro $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null 2>&1; \
 	echo "OK: Repo VCL compiles"; \
 	name="$(CONTAINER_PREFIX)-hostile-$$(openssl rand -hex 4)"; \
-	docker run --rm --name $$name --add-host hostile-backend:127.0.0.1 -v $$(pwd)/test/hostile-backend/default.vcl:/etc/varnish/default.vcl:ro -v $$(pwd)/cache-policy.vcl:/etc/varnish/cache-policy.vcl:ro $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null; \
+	docker run --rm --name $$name --add-host hostile-backend:127.0.0.1 -v $$(pwd)/test/hostile-backend/default.vcl:/etc/varnish/default.vcl:ro -v $$(pwd)/cache-policy.vcl:/etc/varnish/cache-policy.vcl:ro $(IMAGE) varnishd -C -f /etc/varnish/default.vcl >/dev/null 2>&1; \
 	echo "OK: Hostile VCL compiles"; \
 	echo "=== Test: VCL compilation PASSED ==="
 test-smoke:
@@ -83,8 +90,8 @@ test-smoke:
 test-smoke-runtime-interface:
 	@echo "=== Test: Runtime start interface ==="
 	@set -euo pipefail; \
-		name="$(CONTAINER_PREFIX)-runtime-$$(openssl rand -hex 4)"; \
-		host_port=18081; \
+	name="$(CONTAINER_PREFIX)-runtime-$$(openssl rand -hex 4)"; \
+	host_port=18081; \
 		tmpdir=$$(mktemp -d); \
 		trap "docker rm -f $$name >/dev/null 2>&1; rm -rf $$tmpdir" EXIT; \
 		docker run -d --name $$name \
@@ -133,13 +140,84 @@ test-smoke-runtime-interface:
 			cat "$$log_file"; \
 			exit 1; \
 		fi; \
-		if ! grep -q "Invalid VARNISH_LISTEN" "$$log_file"; then \
-			echo "FAIL: invalid VARNISH_LISTEN should fail clearly"; \
-			cat "$$log_file"; \
-			exit 1; \
+	if ! grep -q "Invalid VARNISH_LISTEN" "$$log_file"; then \
+		echo "FAIL: invalid VARNISH_LISTEN should fail clearly"; \
+		cat "$$log_file"; \
+		exit 1; \
+	fi; \
+	log_file="$$tmpdir/start-backend-conflict.log"; \
+	set +e; \
+	docker run --rm -e VARNISH_START='echo hi' -e VARNISH_BACKEND_HOST=localhost $(IMAGE) >"$$log_file" 2>&1 & \
+	pid=$$!; \
+	for _ in 1 2 3 4 5; do \
+		if ! kill -0 $$pid >/dev/null 2>&1; then \
+			break; \
 		fi; \
-		echo "OK: invalid listen configuration failed clearly"; \
-		echo "=== Test: Runtime start interface PASSED ==="
+		sleep 1; \
+	done; \
+	if kill -0 $$pid >/dev/null 2>&1; then \
+		kill $$pid >/dev/null 2>&1 || true; \
+		wait $$pid || true; \
+		status=124; \
+	else \
+		wait $$pid; \
+		status=$$?; \
+	fi; \
+	set -e; \
+	if [ $$status -eq 0 ] || [ $$status -eq 124 ]; then \
+		echo "FAIL: VARNISH_START with VARNISH_BACKEND_* should fail fast"; \
+		cat "$$log_file"; \
+		exit 1; \
+	fi; \
+	if ! grep -q "VARNISH_START cannot be combined" "$$log_file"; then \
+		echo "FAIL: VARNISH_START with VARNISH_BACKEND_* should fail clearly"; \
+		cat "$$log_file"; \
+		exit 1; \
+	fi; \
+	name="$(CONTAINER_PREFIX)-backend-config-$$(openssl rand -hex 4)"; \
+	docker run -d --name $$name \
+		-e VARNISH_BACKEND_HOST=localhost \
+		-e VARNISH_BACKEND_PORT=9090 \
+		-e VARNISH_BACKEND_PROBE_PATH=/healthz \
+		-p 18082:80 \
+		$(IMAGE) >/dev/null; \
+	echo "Waiting for backend-configured container on 18082..."; \
+	timeout=30; \
+	status="000"; \
+	while [ $$timeout -gt 0 ]; do \
+		status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:18082 || true); \
+		if [ "$$status" != "000" ]; then \
+			echo "OK: backend-configured runtime served HTTP $$status"; \
+			break; \
+		fi; \
+		sleep 1; \
+		timeout=$$((timeout - 1)); \
+	done; \
+	if [ "$$status" = "000" ]; then \
+		echo "FAIL: backend-configured runtime did not expose HTTP on 18082"; \
+		docker logs $$name; \
+		docker rm -f $$name >/dev/null 2>&1 || true; \
+		exit 1; \
+	fi; \
+	docker exec $$name grep -q '.host = "localhost";' /etc/varnish/default.vcl || { \
+		echo "FAIL: expected rendered backend host in embedded VCL"; \
+		docker exec $$name cat /etc/varnish/default.vcl; \
+		exit 1; \
+	}; \
+	docker exec $$name grep -q '.port = "9090";' /etc/varnish/default.vcl || { \
+		echo "FAIL: expected rendered backend port in embedded VCL"; \
+		docker exec $$name cat /etc/varnish/default.vcl; \
+		exit 1; \
+	}; \
+	docker exec $$name grep -q '.url = "/healthz";' /etc/varnish/default.vcl || { \
+		echo "FAIL: expected rendered backend probe path in embedded VCL"; \
+		docker exec $$name cat /etc/varnish/default.vcl; \
+		exit 1; \
+	}; \
+	docker exec $$name /usr/sbin/varnishd -C -f /etc/varnish/default.vcl >/dev/null 2>&1; \
+	docker rm -f $$name >/dev/null; \
+	echo "OK: invalid listen configuration failed clearly"; \
+	echo "=== Test: Runtime start interface PASSED ==="
 
 test-integration:
 	@echo "=== Test: Integration test ==="

--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ The container starts `varnishd` from named runtime values instead of a single ba
 
 For advanced cases, `VARNISH_START` still works as a full-command override, but it cannot be combined with the narrower `VARNISH_*` settings.
 
+The embedded standalone VCL also has named backend configuration values:
+
+- `VARNISH_BACKEND_HOST` defaults to `127.0.0.1`
+- `VARNISH_BACKEND_PORT` defaults to `8080`
+- `VARNISH_BACKEND_PROBE_PATH` defaults to `/`
+
+These apply only to the embedded `/etc/varnish/default.vcl`. If you supply a custom `VARNISH_VCL`, keep backend wiring in that VCL instead.
+
 ## VCL Configuration
 
 `default.vcl` is the single source of truth for Varnish config. It includes:
 
-- **Backend health probe** — 2s timeout, 5s interval, sliding window of 5 checks, threshold of 3.
+- **Backend health probe** — 2s timeout, 5s interval, sliding window of 5 checks, threshold of 3. The embedded standalone image can override the probe path with `VARNISH_BACKEND_PROBE_PATH`.
 - **PURGE ACL** — allows cache purging from `localhost` and `127.0.0.1`.
 - **Accept-Encoding normalisation** — normalises to `gzip` or `deflate` for text; unsets for binary assets.
 - **Cookie stripping** — removes cookies for static assets to improve cache hit rates.

--- a/default.vcl.template
+++ b/default.vcl.template
@@ -1,0 +1,17 @@
+vcl 4.0;
+
+probe backend_probe {
+    .url = "__BACKEND_PROBE_PATH__";
+    .timeout = 2s;
+    .interval = 5s;
+    .window = 5;
+    .threshold = 3;
+}
+
+backend default {
+    .host = "__BACKEND_HOST__";
+    .port = "__BACKEND_PORT__";
+    .probe = backend_probe;
+}
+
+include "/etc/varnish/cache-policy.vcl";

--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,12 @@
 apt-get -y update
 apt-get -y install varnish=7.*
 
-cp default.vcl /etc/varnish/default.vcl
+install -m 755 render-vcl.sh /usr/local/bin/render-vcl
+cp default.vcl.template /etc/varnish/default.vcl.template
 cp cache-policy.vcl /etc/varnish/cache-policy.vcl
-sed -i 's/\.host = "web";/.host = "127.0.0.1";/' /etc/varnish/default.vcl
-sed -i 's/\.port = "80";/.port = "8080";/' /etc/varnish/default.vcl
+VARNISH_BACKEND_HOST=127.0.0.1 \
+VARNISH_BACKEND_PORT=8080 \
+VARNISH_BACKEND_PROBE_PATH=/ \
+	/usr/local/bin/render-vcl /etc/varnish/default.vcl.template /etc/varnish/default.vcl
 
 touch /etc/varnish/secret

--- a/render-vcl.sh
+++ b/render-vcl.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+template_path="${1:-/etc/varnish/default.vcl.template}"
+output_path="${2:-/etc/varnish/default.vcl}"
+backend_host="${VARNISH_BACKEND_HOST:-127.0.0.1}"
+backend_port="${VARNISH_BACKEND_PORT:-8080}"
+backend_probe_path="${VARNISH_BACKEND_PROBE_PATH:-/}"
+
+escape_sed_replacement() {
+	printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+if [ ! -f "${template_path}" ]; then
+	echo "ERROR: VCL template '${template_path}' does not exist" >&2
+	exit 1
+fi
+
+case "${backend_port}" in
+	''|*[!0-9]*)
+		echo "ERROR: Invalid VARNISH_BACKEND_PORT '${backend_port}'; expected digits" >&2
+		exit 1
+		;;
+esac
+
+case "${backend_probe_path}" in
+	/*) ;;
+	*)
+		echo "ERROR: Invalid VARNISH_BACKEND_PROBE_PATH '${backend_probe_path}'; expected absolute path" >&2
+		exit 1
+		;;
+esac
+
+sed \
+	-e "s/__BACKEND_HOST__/$(escape_sed_replacement "${backend_host}")/g" \
+	-e "s/__BACKEND_PORT__/$(escape_sed_replacement "${backend_port}")/g" \
+	-e "s/__BACKEND_PROBE_PATH__/$(escape_sed_replacement "${backend_probe_path}")/g" \
+	"${template_path}" > "${output_path}"

--- a/start.sh
+++ b/start.sh
@@ -8,8 +8,8 @@ fail() {
 }
 
 if [ -n "${VARNISH_START:-}" ]; then
-	if [ -n "${VARNISH_LISTEN:-}" ] || [ -n "${VARNISH_VCL:-}" ] || [ -n "${VARNISH_STORAGE:-}" ] || [ -n "${VARNISH_EXTRA_ARGS:-}" ]; then
-		fail "VARNISH_START cannot be combined with VARNISH_LISTEN, VARNISH_VCL, VARNISH_STORAGE, or VARNISH_EXTRA_ARGS"
+	if [ -n "${VARNISH_LISTEN:-}" ] || [ -n "${VARNISH_VCL:-}" ] || [ -n "${VARNISH_STORAGE:-}" ] || [ -n "${VARNISH_EXTRA_ARGS:-}" ] || [ -n "${VARNISH_BACKEND_HOST:-}" ] || [ -n "${VARNISH_BACKEND_PORT:-}" ] || [ -n "${VARNISH_BACKEND_PROBE_PATH:-}" ]; then
+		fail "VARNISH_START cannot be combined with VARNISH_LISTEN, VARNISH_VCL, VARNISH_STORAGE, VARNISH_EXTRA_ARGS, or VARNISH_BACKEND_*"
 	fi
 
 	exec /bin/bash -lc "${VARNISH_START}"
@@ -19,6 +19,20 @@ listen="${VARNISH_LISTEN:-0.0.0.0:80}"
 vcl_path="${VARNISH_VCL:-/etc/varnish/default.vcl}"
 storage="${VARNISH_STORAGE:-malloc,1g}"
 extra_args="${VARNISH_EXTRA_ARGS:-}"
+backend_host="${VARNISH_BACKEND_HOST:-}"
+backend_port="${VARNISH_BACKEND_PORT:-}"
+backend_probe_path="${VARNISH_BACKEND_PROBE_PATH:-}"
+
+if [ -n "${backend_host}${backend_port}${backend_probe_path}" ]; then
+	if [ "${vcl_path}" != "/etc/varnish/default.vcl" ]; then
+		fail "VARNISH_BACKEND_* requires VARNISH_VCL to be /etc/varnish/default.vcl"
+	fi
+
+	VARNISH_BACKEND_HOST="${backend_host:-127.0.0.1}" \
+	VARNISH_BACKEND_PORT="${backend_port:-8080}" \
+	VARNISH_BACKEND_PROBE_PATH="${backend_probe_path:-/}" \
+		/usr/local/bin/render-vcl /etc/varnish/default.vcl.template "${vcl_path}"
+fi
 
 case "${listen}" in
 	*:* ) ;;


### PR DESCRIPTION
## Summary
- replace standalone image backend sed patching with a rendered VCL template and named backend envs
- apply backend config overrides through the real container startup path and document the new interface
- add compile and runtime smoke coverage for configured backend output and VARNISH_START conflicts

## Testing
- make test

Closes #14