### PR TITLE
Create shared runner for hostile E2E scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ test-grace:
 
 test-hostile-static-cookie:
 	@echo "=== Test: Hostile static asset strips cookies and stays cacheable ==="
-	@set -euo pipefail; \
+	@./test/e2e/run-hostile-scenario.sh static-cookie; exit $$?; \
 	lockdir="/tmp/varnish-hostile-8081.lock"; \
 	acquired=0; \
 	while [ $$acquired -eq 0 ]; do \

--- a/test/e2e/assert-hostile-static-cookie.sh
+++ b/test/e2e/assert-hostile-static-cookie.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tmpdir="${TEST_TMPDIR:?TEST_TMPDIR must be set}"
+url="http://localhost:8081/static/app.css"
+
+echo "Purging any existing cached asset..."
+status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X PURGE "$url")"
+if [ "$status" != "200" ]; then
+	echo "FAIL: Expected PURGE HTTP 200, got $status"
+	exit 1
+fi
+
+resp1_headers="$tmpdir/resp1.headers"
+resp1_body="$tmpdir/resp1.body"
+resp2_headers="$tmpdir/resp2.headers"
+resp2_body="$tmpdir/resp2.body"
+
+echo "Requesting static asset with Cookie (first request)..."
+curl -sS --max-time 10 -D "$resp1_headers" -o "$resp1_body" -H 'Cookie: client=alice' "$url"
+
+if ! grep -q '^asset=app.css$' "$resp1_body"; then
+	echo "FAIL: Expected first response body contain asset=app.css"
+	cat "$resp1_body"
+	exit 1
+fi
+
+if ! grep -q '^cookie=none$' "$resp1_body"; then
+	echo "FAIL: Expected first response body to contain cookie=none"
+	cat "$resp1_body"
+	exit 1
+fi
+
+if ! grep -qi '^X-Cache: MISS' "$resp1_headers"; then
+	echo "FAIL: Expected first response X-Cache: MISS"
+	cat "$resp1_headers"
+	exit 1
+fi
+
+echo "OK: First request reached origin without Cookie and was a MISS"
+echo "Requesting static asset with Cookie (second request)..."
+curl -sS --max-time 10 -D "$resp2_headers" -o "$resp2_body" -H 'Cookie: client=alice' "$url"
+
+if ! grep -q '^asset=app.css$' "$resp2_body"; then
+	echo "FAIL: Expected second response body contain asset=app.css"
+	cat "$resp2_body"
+	exit 1
+fi
+
+if ! grep -q '^cookie=none$' "$resp2_body"; then
+	echo "FAIL: Expected second response body contain cookie=none"
+	cat "$resp2_body"
+	exit 1
+fi
+
+if ! grep -qi '^X-Cache: HIT' "$resp2_headers"; then
+	echo "FAIL: Expected second response X-Cache: HIT"
+	cat "$resp2_headers"
+	exit 1
+fi
+
+echo "OK: Second request stayed cacheable and was a HIT"
+echo "=== Test: Hostile static asset strips cookies and stays cacheable PASSED ==="

--- a/test/e2e/run-hostile-scenario.sh
+++ b/test/e2e/run-hostile-scenario.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario="${1:-}"
+
+if [ -z "$scenario" ]; then
+	echo "Usage: $0 <scenario>" >&2
+	exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+compose() {
+	docker compose -p "$project" -f "$repo_root/docker-compose.yml" -f "$repo_root/docker-compose.hostile.yml" "$@"
+}
+
+cleanup() {
+	if [ -n "${tmpdir:-}" ] && [ -d "${tmpdir:-}" ]; then
+		rm -rf "$tmpdir"
+	fi
+
+	if [ -n "${lockdir:-}" ]; then
+		rm -rf "$lockdir"
+	fi
+
+	if [ -n "${project:-}" ]; then
+		compose down --remove-orphans >/dev/null 2>&1 || true
+	fi
+}
+
+wait_for_ready() {
+	local timeout="$1"
+	local readiness_url="$2"
+	local ready_message="$3"
+
+	while [ "$timeout" -gt 0 ]; do
+		if curl -sf --max-time 10 "$readiness_url" >/dev/null 2>&1; then
+			echo "$ready_message"
+			return 0
+		fi
+
+		sleep 2
+		timeout=$((timeout - 2))
+	done
+
+	return 1
+}
+
+case "$scenario" in
+	static-cookie)
+		lockdir="/tmp/varnish-hostile-8081.lock"
+		project="varnish-hostile-static-$$"
+		readiness_url="http://localhost:8081/ready"
+		assertion_script="$repo_root/test/e2e/assert-hostile-static-cookie.sh"
+		services=(hostile-backend varnish-hostile)
+		;;
+	*)
+		echo "Unknown hostile scenario: $scenario" >&2
+		exit 1
+		;;
+esac
+
+trap cleanup EXIT
+
+while ! mkdir "$lockdir" 2>/dev/null; do
+	sleep 1
+done
+
+tmpdir="$(mktemp -d)"
+
+compose up -d --build "${services[@]}"
+
+echo "Waiting hostile services to be ready..."
+if ! wait_for_ready 60 "$readiness_url" "OK: Hostile services ready"; then
+	echo "FAIL: Hostile services did not become ready within 60s"
+	compose logs
+	exit 1
+fi
+
+export TEST_TMPDIR="$tmpdir"
+"$assertion_script"


### PR DESCRIPTION
## Summary
- add a shared hostile-scenario runner that owns compose startup, readiness polling, locks, teardown, and failure logs
- move the static-cookie hostile backend scenario behind the shared runner without changing its HTTP assertions
- keep the existing Make target interface while exercising the same real Docker Compose and HTTP path

## Testing
- make test-hostile-static-cookie
- make test
- make test-e2e-hard

Closes #16