### PR TITLE
test: add hostile cache-policy drift canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace test-perf test-e2e-hard test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -22,7 +22,7 @@ test-makefile-shell:
 
 test: build test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace
 
-test-e2e-hard: test-hostile-static-cookie test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+test-e2e-hard: test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 test-existence:
 	@echo "=== Test: File existence ==="
@@ -368,7 +368,7 @@ test-grace:
 
 test-hostile-static-cookie:
 	@echo "=== Test: Hostile static asset strips cookies and stays cacheable ==="
-	@./test/e2e/run-hostile-scenario.sh static-cookie; exit $$?; \
+	@./test/e2e/run-hostile-scenario.sh static-cookie
 	lockdir="/tmp/varnish-hostile-8081.lock"; \
 	acquired=0; \
 	while [ $$acquired -eq 0 ]; do \
@@ -446,6 +446,18 @@ test-hostile-static-cookie:
 	fi; \
 	echo "OK: Second request stayed cacheable and was a HIT"; \
 	echo "=== Test: Hostile static asset strips cookies and stays cacheable PASSED ==="
+
+test-hostile-static-cookie-canary:
+	@echo "=== Test: Hostile static asset depends on shared cache policy ==="
+	@set -euo pipefail; \
+	log_file=$$(mktemp); \
+	trap 'rm -f "$$log_file"' EXIT; \
+	if HOSTILE_CACHE_POLICY_PATH="$$(pwd)/test/e2e/fixtures/cache-policy-static-cookie-pass.vcl" ./test/e2e/run-hostile-scenario.sh static-cookie >"$$log_file" 2>&1; then \
+		echo "FAIL: hostile static-cookie scenario passed with a mutant shared cache policy"; \
+		cat "$$log_file"; \
+		exit 1; \
+	fi; \
+	echo "OK: hostile static-cookie scenario failed under mutant shared cache policy"
 
 test-hostile-account-cookie-isolation:
 	@echo "=== Test: Hostile account requests with cookies stay isolated per client ==="

--- a/docker-compose.hostile.yml
+++ b/docker-compose.hostile.yml
@@ -17,7 +17,7 @@ services:
       - "8081:80"
     volumes:
       - ./test/hostile-backend/default.vcl:/etc/varnish/default.vcl:ro
-      - ./cache-policy.vcl:/etc/varnish/cache-policy.vcl:ro
+      - ${HOSTILE_CACHE_POLICY_PATH:-./cache-policy.vcl}:/etc/varnish/cache-policy.vcl:ro
     depends_on:
       hostile-backend:
         condition: service_healthy

--- a/test/e2e/fixtures/cache-policy-static-cookie-pass.vcl
+++ b/test/e2e/fixtures/cache-policy-static-cookie-pass.vcl
@@ -1,0 +1,44 @@
+acl purge {
+    "localhost";
+    "127.0.0.1";
+    "10.0.0.0"/8;
+    "172.16.0.0"/12;
+    "192.168.0.0"/16;
+}
+
+sub vcl_recv {
+    if (req.method == "PURGE") {
+        if (!client.ip ~ purge) {
+            return (synth(405, "Not allowed"));
+        }
+
+        return (purge);
+    }
+
+    if (req.url ~ "\.(css|js|png|jpg|jpeg|gif|ico|svg|webp|avif|woff|woff2|ttf|eot|otf|mp3|ogg|webm|gz|tgz|bz2|tbz)$") {
+        return (pass);
+    }
+
+    if (req.http.Cookie) {
+        return (pass);
+    }
+}
+
+sub vcl_backend_response {
+    if (bereq.url ~ "\.(css|js|png|jpg|jpeg|gif|ico|svg|webp|avif|woff|woff2|ttf|eot|otf|mp3|ogg|webm|gz|tgz|bz2|tbz)$") {
+        set beresp.ttl = 1d;
+        set beresp.grace = 7d;
+    } else {
+        set beresp.ttl = 0s;
+        set beresp.grace = 0s;
+        set beresp.uncacheable = true;
+    }
+}
+
+sub vcl_deliver {
+    if (obj.hits > 0) {
+        set resp.http.X-Cache = "HIT";
+    } else {
+        set resp.http.X-Cache = "MISS";
+    }
+}


### PR DESCRIPTION
## Summary
- add a hostile E2E canary that injects a mutant shared cache policy and expects the static-cookie proof to fail
- allow the hostile compose path to mount an alternate shared cache-policy file for canary and future mutation-style checks
- add the canary to `make test-e2e-hard`

## Testing
- make test
- make test-e2e-hard

Closes #13