### PR TITLE
Add semantic HTTP cache assertions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -457,6 +457,11 @@ test-hostile-static-cookie-canary:
 		cat "$$log_file"; \
 		exit 1; \
 	fi; \
+	if ! grep -Eq "first static asset request|second static asset request" "$$log_file"; then \
+		echo "FAIL: hostile static-cookie canary should fail with semantic cache-domain assertion"; \
+		cat "$$log_file"; \
+		exit 1; \
+	fi; \
 	echo "OK: hostile static-cookie scenario failed under mutant shared cache policy"
 
 test-hostile-account-cookie-isolation:

--- a/test/e2e/assert-hostile-static-cookie.sh
+++ b/test/e2e/assert-hostile-static-cookie.sh
@@ -1,64 +1,29 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-tmpdir="${TEST_TMPDIR:?TEST_TMPDIR must be set}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$repo_root/test/e2e/http-cache-assert.sh"
+
 url="http://localhost:8081/static/app.css"
 
 echo "Purging any existing cached asset..."
-status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -X PURGE "$url")"
-if [ "$status" != "200" ]; then
-	echo "FAIL: Expected PURGE HTTP 200, got $status"
-	exit 1
-fi
-
-resp1_headers="$tmpdir/resp1.headers"
-resp1_body="$tmpdir/resp1.body"
-resp2_headers="$tmpdir/resp2.headers"
-resp2_body="$tmpdir/resp2.body"
+http_request purge-static-cookie "$url" -X PURGE
+assert_http_status purge-static-cookie 200 "static asset PURGE"
 
 echo "Requesting static asset with Cookie (first request)..."
-curl -sS --max-time 10 -D "$resp1_headers" -o "$resp1_body" -H 'Cookie: client=alice' "$url"
+http_request static-cookie-first "$url" -H 'Cookie: client=alice'
+assert_cache_state static-cookie-first MISS "first static asset request"
+assert_header_contains static-cookie-first Content-Type "text/css" "first static asset request"
+assert_body_field_equals static-cookie-first asset "app.css" "first static asset request"
+assert_body_field_equals static-cookie-first cookie "none" "first static asset request"
+first_request_id="$(assert_origin_request_id_present static-cookie-first "first static asset request")"
+echo "OK: First request was cache miss against origin request ${first_request_id}"
 
-if ! grep -q '^asset=app.css$' "$resp1_body"; then
-	echo "FAIL: Expected first response body contain asset=app.css"
-	cat "$resp1_body"
-	exit 1
-fi
-
-if ! grep -q '^cookie=none$' "$resp1_body"; then
-	echo "FAIL: Expected first response body to contain cookie=none"
-	cat "$resp1_body"
-	exit 1
-fi
-
-if ! grep -qi '^X-Cache: MISS' "$resp1_headers"; then
-	echo "FAIL: Expected first response X-Cache: MISS"
-	cat "$resp1_headers"
-	exit 1
-fi
-
-echo "OK: First request reached origin without Cookie and was a MISS"
 echo "Requesting static asset with Cookie (second request)..."
-curl -sS --max-time 10 -D "$resp2_headers" -o "$resp2_body" -H 'Cookie: client=alice' "$url"
-
-if ! grep -q '^asset=app.css$' "$resp2_body"; then
-	echo "FAIL: Expected second response body contain asset=app.css"
-	cat "$resp2_body"
-	exit 1
-fi
-
-if ! grep -q '^cookie=none$' "$resp2_body"; then
-	echo "FAIL: Expected second response body contain cookie=none"
-	cat "$resp2_body"
-	exit 1
-fi
-
-if ! grep -qi '^X-Cache: HIT' "$resp2_headers"; then
-	echo "FAIL: Expected second response X-Cache: HIT"
-	cat "$resp2_headers"
-	exit 1
-fi
-
-echo "OK: Second request stayed cacheable and was a HIT"
-echo "=== Test: Hostile static asset strips cookies and stays cacheable PASSED ==="
+http_request static-cookie-second "$url" -H 'Cookie: client=alice'
+assert_cache_state static-cookie-second HIT "second static asset request"
+assert_header_contains static-cookie-second Content-Type "text/css" "second static asset request"
+assert_body_field_equals static-cookie-second asset "app.css" "second static asset request"
+assert_body_field_equals static-cookie-second cookie "none" "second static asset request"
+assert_same_origin_request_id static-cookie-second "$first_request_id" "second static asset request"
+echo "OK: Second request was cache hit reusing origin request ${first_request_id}"

--- a/test/e2e/http-cache-assert.sh
+++ b/test/e2e/http-cache-assert.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+response_headers_path() {
+    printf '%s/%s.headers\n' "${TEST_TMPDIR:?TEST_TMPDIR must be set}" "$1"
+}
+
+response_body_path() {
+    printf '%s/%s.body\n' "${TEST_TMPDIR:?TEST_TMPDIR must be set}" "$1"
+}
+
+response_status_code() {
+    local name="$1"
+    sed -n '1s/.* \([0-9][0-9][0-9]\).*/\1/p' "$(response_headers_path "$name")"
+}
+
+response_header_value() {
+    local name="$1"
+    local header_name="$2"
+    local header_file
+    header_file="$(response_headers_path "$name")"
+
+    grep -i "^${header_name}:" "$header_file" \
+        | tail -n 1 \
+        | tr -d '\r' \
+        | sed 's/^[^:]*:[[:space:]]*//'
+}
+
+response_body_field_value() {
+    local name="$1"
+    local field_name="$2"
+    local body_file
+    body_file="$(response_body_path "$name")"
+
+    grep "^${field_name}=" "$body_file" \
+        | tail -n 1 \
+        | cut -d= -f2-
+}
+
+dump_response() {
+    local name="$1"
+    local headers_file
+    local body_file
+    headers_file="$(response_headers_path "$name")"
+    body_file="$(response_body_path "$name")"
+
+    echo "--- ${name} headers ---"
+    cat "$headers_file"
+    echo "--- ${name} body ---"
+    cat "$body_file"
+}
+
+fail_response_assertion() {
+    local message="$1"
+    local name="$2"
+
+    echo "FAIL: ${message}"
+    dump_response "$name"
+    exit 1
+}
+
+http_request() {
+    local name="$1"
+    local url="$2"
+    shift 2
+
+    curl -sS --max-time 10 \
+        -D "$(response_headers_path "$name")" \
+        -o "$(response_body_path "$name")" \
+        "$@" \
+        "$url"
+}
+
+assert_http_status() {
+    local name="$1"
+    local expected_status="$2"
+    local context="$3"
+    local actual_status
+    actual_status="$(response_status_code "$name")"
+
+    if [ "$actual_status" != "$expected_status" ]; then
+        fail_response_assertion \
+            "expected ${context} HTTP ${expected_status}, got ${actual_status:-missing}" \
+            "$name"
+    fi
+}
+
+assert_cache_state() {
+    local name="$1"
+    local expected_state="$2"
+    local context="$3"
+    local actual_state
+    actual_state="$(response_header_value "$name" "X-Cache" || true)"
+
+    if [[ "$actual_state" != *"$expected_state"* ]]; then
+        fail_response_assertion \
+            "expected ${context} cache ${expected_state,,}, got '${actual_state:-missing}'" \
+            "$name"
+    fi
+}
+
+assert_header_contains() {
+    local name="$1"
+    local header_name="$2"
+    local expected_fragment="$3"
+    local context="$4"
+    local actual_value
+    actual_value="$(response_header_value "$name" "$header_name" || true)"
+
+    if [[ "$actual_value" != *"$expected_fragment"* ]]; then
+        fail_response_assertion \
+            "expected ${context} header ${header_name} contain '${expected_fragment}', got '${actual_value:-missing}'" \
+            "$name"
+    fi
+}
+
+assert_body_field_equals() {
+    local name="$1"
+    local field_name="$2"
+    local expected_value="$3"
+    local context="$4"
+    local actual_value
+    actual_value="$(response_body_field_value "$name" "$field_name" || true)"
+
+    if [ "$actual_value" != "$expected_value" ]; then
+        fail_response_assertion \
+            "expected ${context} body field ${field_name}=${expected_value}, got '${actual_value:-missing}'" \
+            "$name"
+    fi
+}
+
+assert_origin_request_id_present() {
+    local name="$1"
+    local context="$2"
+    local request_id
+    request_id="$(response_header_value "$name" "X-Backend-Request-Id" || true)"
+
+    if [ -z "$request_id" ]; then
+        fail_response_assertion \
+            "expected ${context} include origin request id header X-Backend-Request-Id" \
+            "$name"
+    fi
+
+    printf '%s\n' "$request_id"
+}
+
+assert_same_origin_request_id() {
+    local name="$1"
+    local expected_request_id="$2"
+    local context="$3"
+    local actual_request_id
+    actual_request_id="$(assert_origin_request_id_present "$name" "$context")"
+
+    if [ "$actual_request_id" != "$expected_request_id" ]; then
+        fail_response_assertion \
+            "expected ${context} reuse origin request id ${expected_request_id}, got ${actual_request_id}" \
+            "$name"
+    fi
+}


### PR DESCRIPTION
## Summary
- add a shared shell assertion adapter for HTTP cache scenario responses
- move the hostile static-cookie scenario onto semantic cache/header/body/request-id assertions
- tighten the mutant canary so it expects semantic scenario failure output

## Testing
- make test
- make test-e2e-hard

Closes #17