### PR TITLE
Document Varnish container restart workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace test-perf test-e2e-hard test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+.PHONY: build test test-makefile-shell test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-integration test-security test-purge test-grace test-perf test-e2e-hard test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -20,7 +20,16 @@ test-makefile-shell:
 	@set -euo pipefail; echo "OK: pipefail supported"
 	@echo "=== Test: Makefile shell compatibility PASSED ==="
 
-test: build test-existence test-vcl-compile test-smoke test-smoke-runtime-interface test-integration test-security test-purge test-grace
+test: build test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-integration test-security test-purge test-grace
+
+test-restart-docs:
+	@echo "=== Test: Restart documentation ==="
+	@set -euo pipefail; \
+		grep -q "docker restart" README.md; \
+		grep -q "docker compose restart varnish" README.md; \
+		grep -q "sudo service varnish restart" README.md; \
+		echo "OK: README documents container restart workflow"; \
+		echo "=== Test: Restart documentation PASSED ==="
 
 test-e2e-hard: test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
@@ -86,6 +95,37 @@ test-smoke:
 		docker exec $$name varnishadm status >/dev/null; \
 		echo "OK: varnishadm status responded"; \
 		echo "=== Test: Smoke test PASSED ==="
+
+test-container-restart:
+	@echo "=== Test: Container restart ==="
+	@set -euo pipefail; \
+		name="$(CONTAINER_PREFIX)-restart-$$(openssl rand -hex 4)"; \
+		host_port=18083; \
+		docker run -d --name $$name -p $$host_port:80 $(IMAGE) >/dev/null; \
+		trap "docker rm -f $$name >/dev/null 2>&1" EXIT; \
+		for phase in initial restarted; do \
+			if [ "$$phase" = "restarted" ]; then \
+				docker restart $$name >/dev/null; \
+			fi; \
+			echo "Waiting for $$phase varnishd HTTP on $$host_port..."; \
+			timeout=30; \
+			status="000"; \
+			while [ $$timeout -gt 0 ]; do \
+				status=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:$$host_port || true); \
+				if [ "$$status" != "000" ]; then \
+					echo "OK: $$phase container served HTTP $$status"; \
+					break; \
+				fi; \
+				sleep 1; \
+				timeout=$$((timeout - 1)); \
+			done; \
+			if [ "$$status" = "000" ]; then \
+				echo "FAIL: $$phase container did not expose HTTP on $$host_port"; \
+				docker logs $$name; \
+				exit 1; \
+			fi; \
+		done; \
+		echo "=== Test: Container restart PASSED ==="
 
 test-smoke-runtime-interface:
 	@echo "=== Test: Runtime start interface ==="

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ The embedded standalone backend configuration also has named values:
 
 These apply only to the embedded `/etc/varnish/backend.vcl`. If you supply a custom `VARNISH_VCL`, keep backend wiring in that VCL instead.
 
+## Restarting Varnish
+
+This image runs `varnishd` as the container process, not as a distro service.
+Do not run `sudo service varnish restart` inside the container.
+
+Restart the container instead:
+
+```bash
+docker restart <container-name>
+```
+
+With the sample Compose file, restart the Varnish service:
+
+```bash
+docker compose restart varnish
+```
+
+If you changed mounted VCL files, restart the container so `varnishd` starts
+again with the updated configuration. If you changed image files, rebuild first
+with `docker compose up -d --build`.
+
 ## VCL Configuration
 
 `default.vcl` is the compose-facing Varnish config. The standalone image uses the same cache policy with a generated backend include. The config includes:


### PR DESCRIPTION
## Summary
- document that Varnish should be restarted by restarting the container, not via distro service commands inside the container
- add README canary coverage for the restart guidance
- add a real Docker smoke test proving the image serves HTTP before and after docker restart

Closes #2.

## Tests
- make test-restart-docs
- make test-container-restart
- make test
- make test-e2e-hard