### PR TITLE
Deepen E2E harness module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: build test test-makefile-shell test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-backend-config-adapter test-integration test-security test-purge test-grace test-perf test-e2e-hard test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+.PHONY: build test test-makefile-shell test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-backend-config-adapter test-integration test-security test-purge test-grace test-perf test-e2e-hard test-e2e-harness-module test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 IMAGE := jonbaldie/varnish:latest
 CONTAINER_PREFIX := varnish-test
@@ -20,7 +20,7 @@ test-makefile-shell:
 	@set -euo pipefail; echo "OK: pipefail supported"
 	@echo "=== Test: Makefile shell compatibility PASSED ==="
 
-test: build test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-backend-config-adapter test-integration test-security test-purge test-grace
+test: build test-restart-docs test-existence test-vcl-compile test-smoke test-container-restart test-smoke-runtime-interface test-backend-config-adapter test-e2e-harness-module test-integration test-security test-purge test-grace
 
 test-restart-docs:
 	@echo "=== Test: Restart documentation ==="
@@ -31,7 +31,7 @@ test-restart-docs:
 		echo "OK: README documents container restart workflow"; \
 		echo "=== Test: Restart documentation PASSED ==="
 
-test-e2e-hard: test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
+test-e2e-hard: test-e2e-harness-module test-e2e-scenario-config test-hostile-static-cookie test-hostile-static-cookie-canary test-hostile-account-cookie-isolation test-hostile-set-cookie-isolation test-5xx-not-cached test-purge-unauthorized test-post-not-cached test-grace-stale
 
 test-existence:
 	@echo "=== Test: File existence ==="
@@ -446,6 +446,10 @@ test-hostile-set-cookie-isolation:
 test-e2e-scenario-config:
 	@echo "=== Test: E2E hostile scenario config ==="
 	@./test/e2e/assert-scenario-compose-config.sh
+
+test-e2e-harness-module:
+	@echo "=== Test: E2E harness module ==="
+	@./test/e2e/assert-e2e-harness-module.sh
 
 test-5xx-not-cached:
 	@echo "=== Test: Backend 5xx responses not served from cache ==="

--- a/test/e2e/assert-e2e-harness-module.sh
+++ b/test/e2e/assert-e2e-harness-module.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+runner="$repo_root/test/e2e/run-hostile-scenario.sh"
+
+description="$("$runner" --describe 5xx)"
+
+echo "$description" | grep -q '^scenario=5xx$' || {
+  echo "FAIL: 5xx scenario description should include scenario name"
+  echo "$description"
+  exit 1
+}
+
+echo "$description" | grep -q '^port=8082$' || {
+  echo "FAIL: 5xx scenario description should include exposed port"
+  echo "$description"
+  exit 1
+}
+
+echo "$description" | grep -q '^readiness_url=http://localhost:8082/ready$' || {
+  echo "FAIL: 5xx scenario description should include readiness URL"
+  echo "$description"
+  exit 1
+}
+
+echo "$description" | grep -q 'assertion_script=.*/test/e2e/assert-hostile-5xx.sh$' || {
+  echo "FAIL: 5xx scenario description should include semantic assertion script"
+  echo "$description"
+  exit 1
+}
+
+set +e
+unknown_output="$("$runner" --describe does-not-exist 2>&1)"
+unknown_status=$?
+set -e
+
+if [ "$unknown_status" -eq 0 ]; then
+  echo "FAIL: unknown scenario should fail"
+  echo "$unknown_output"
+  exit 1
+fi
+
+echo "$unknown_output" | grep -q 'Unknown hostile scenario: does-not-exist' || {
+  echo "FAIL: unknown scenario should name the bad scenario"
+  echo "$unknown_output"
+  exit 1
+}
+
+echo "$unknown_output" | grep -q 'Available scenarios: static-cookie, account-cookie, set-cookie, 5xx, post, grace, purge-acl' || {
+  echo "FAIL: unknown scenario should list available scenarios"
+  echo "$unknown_output"
+  exit 1
+}
+
+echo "OK: E2E harness exposes scenario metadata and useful failures"

--- a/test/e2e/run-hostile-scenario.sh
+++ b/test/e2e/run-hostile-scenario.sh
@@ -4,15 +4,105 @@ set -euo pipefail
 
 scenario="${1:-}"
 
-if [ -z "$scenario" ]; then
-	echo "Usage: $0 <scenario>" >&2
-	exit 1
-fi
-
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-compose_files=("$repo_root/docker-compose.yml" "$repo_root/docker-compose.hostile.yml")
 ready_timeout=60
 curl_max_time=10
+available_scenarios=(static-cookie account-cookie set-cookie 5xx post grace purge-acl)
+
+usage() {
+  echo "Usage: $0 <scenario>" >&2
+  echo "       $0 --describe <scenario>" >&2
+}
+
+available_scenarios_text() {
+  local separator=""
+  local scenario_name
+
+  for scenario_name in "${available_scenarios[@]}"; do
+    printf '%s%s' "$separator" "$scenario_name"
+    separator=", "
+  done
+  printf '\n'
+}
+
+unknown_scenario() {
+  local name="$1"
+  echo "Unknown hostile scenario: ${name}" >&2
+  echo "Available scenarios: $(available_scenarios_text)" >&2
+  exit 1
+}
+
+use_legacy_hostile_compose() {
+  compose_files=("$repo_root/docker-compose.yml" "$repo_root/docker-compose.hostile.yml")
+  port=8081
+  lockdir="/tmp/varnish-hostile-${port}.lock"
+  project="varnish-hostile-${scenario}-$$"
+  readiness_url="http://localhost:${port}/ready"
+  services=(hostile-backend varnish-hostile)
+}
+
+use_scenario_compose() {
+  local slug="$1"
+  local scenario_port="$2"
+
+  compose_files=("$repo_root/docker-compose.e2e-scenario.yml")
+  port="$scenario_port"
+  lockdir="/tmp/varnish-${slug}-${port}.lock"
+  project="varnish-${slug}-$$"
+  HOSTILE_SCENARIO_PORT="$port"
+  readiness_url="http://localhost:${port}/ready"
+  services=()
+  curl_max_time=5
+}
+
+configure_scenario() {
+  case "$scenario" in
+    static-cookie)
+      use_legacy_hostile_compose
+      assertion_script="$repo_root/test/e2e/assert-hostile-static-cookie.sh"
+      ;;
+    account-cookie)
+      use_legacy_hostile_compose
+      assertion_script="$repo_root/test/e2e/assert-hostile-account-cookie.sh"
+      ;;
+    set-cookie)
+      use_legacy_hostile_compose
+      assertion_script="$repo_root/test/e2e/assert-hostile-set-cookie.sh"
+      ;;
+    5xx)
+      use_scenario_compose "5xx-test" 8082
+      assertion_script="$repo_root/test/e2e/assert-hostile-5xx.sh"
+      ;;
+    post)
+      use_scenario_compose "post-test" 8084
+      assertion_script="$repo_root/test/e2e/assert-hostile-post.sh"
+      ;;
+    grace)
+      use_scenario_compose "grace-stale" 8083
+      assertion_script="$repo_root/test/e2e/assert-hostile-grace.sh"
+      ;;
+    purge-acl)
+      use_scenario_compose "purge-acl" 8085
+      HOSTILE_SCENARIO_SUBNET=203.0.113.0/24
+      HOSTILE_SCENARIO_VARNISH_IP=203.0.113.2
+      assertion_script="$repo_root/test/e2e/assert-hostile-purge-acl.sh"
+      ;;
+    *)
+      unknown_scenario "$scenario"
+      ;;
+  esac
+}
+
+describe_scenario() {
+  configure_scenario
+
+  echo "scenario=$scenario"
+  echo "port=$port"
+  echo "readiness_url=$readiness_url"
+  echo "assertion_script=$assertion_script"
+  echo "compose_files=$(IFS=:; echo "${compose_files[*]}")"
+  echo "services=$(IFS=,; echo "${services[*]-}")"
+}
 
 compose() {
   local args=(-p "$project")
@@ -26,106 +116,53 @@ compose() {
 }
 
 cleanup() {
-	if [ -n "${tmpdir:-}" ] && [ -d "${tmpdir:-}" ]; then
-		rm -rf "$tmpdir"
-	fi
+  if [ -n "${tmpdir:-}" ] && [ -d "${tmpdir:-}" ]; then
+    rm -rf "$tmpdir"
+  fi
 
-	if [ -n "${lockdir:-}" ]; then
-		rm -rf "$lockdir"
-	fi
+  if [ -n "${lockdir:-}" ]; then
+    rm -rf "$lockdir"
+  fi
 
-	if [ -n "${project:-}" ]; then
-		compose down --remove-orphans >/dev/null 2>&1 || true
-	fi
+  if [ -n "${project:-}" ]; then
+    compose down --remove-orphans >/dev/null 2>&1 || true
+  fi
 }
 
 wait_for_ready() {
-	local timeout="$1"
-	local readiness_url="$2"
-	local ready_message="$3"
+  local timeout="$1"
+  local ready_url="$2"
+  local ready_message="$3"
 
-	while [ "$timeout" -gt 0 ]; do
-		if curl -sf --max-time 10 "$readiness_url" >/dev/null 2>&1; then
-			echo "$ready_message"
-			return 0
-		fi
+  while [ "$timeout" -gt 0 ]; do
+    if curl -sf --max-time 10 "$ready_url" >/dev/null 2>&1; then
+      echo "$ready_message"
+      return 0
+    fi
 
-		sleep 2
-		timeout=$((timeout - 2))
-	done
+    sleep 2
+    timeout=$((timeout - 2))
+  done
 
-	return 1
+  return 1
 }
 
-case "$scenario" in
-  static-cookie)
-    lockdir="/tmp/varnish-hostile-8081.lock"
-    project="varnish-hostile-static-$$"
-    readiness_url="http://localhost:8081/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-static-cookie.sh"
-    services=(hostile-backend varnish-hostile)
-    ;;
-  account-cookie)
-    lockdir="/tmp/varnish-hostile-8081.lock"
-    project="varnish-hostile-account-$$"
-    readiness_url="http://localhost:8081/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-account-cookie.sh"
-    services=(hostile-backend varnish-hostile)
-    ;;
-  set-cookie)
-    lockdir="/tmp/varnish-hostile-8081.lock"
-    project="varnish-hostile-set-cookie-$$"
-    readiness_url="http://localhost:8081/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-set-cookie.sh"
-    services=(hostile-backend varnish-hostile)
-    ;;
-  5xx)
-        compose_files=("$repo_root/docker-compose.e2e-scenario.yml")
-        lockdir="/tmp/varnish-5xx-test-8082.lock"
-        project="varnish-5xx-test-$$"
-        HOSTILE_SCENARIO_PORT=8082
-        readiness_url="http://localhost:8082/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-5xx.sh"
-    services=()
-    curl_max_time=5
-    ;;
-  post)
-        compose_files=("$repo_root/docker-compose.e2e-scenario.yml")
-        lockdir="/tmp/varnish-post-test-8084.lock"
-        project="varnish-post-test-$$"
-        HOSTILE_SCENARIO_PORT=8084
-        readiness_url="http://localhost:8084/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-post.sh"
-    services=()
-    curl_max_time=5
-    ;;
-  grace)
-        compose_files=("$repo_root/docker-compose.e2e-scenario.yml")
-        lockdir="/tmp/varnish-grace-stale-8083.lock"
-        project="varnish-grace-stale-$$"
-        HOSTILE_SCENARIO_PORT=8083
-        readiness_url="http://localhost:8083/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-grace.sh"
-    services=()
-    curl_max_time=5
-    ;;
-  purge-acl)
-        compose_files=("$repo_root/docker-compose.e2e-scenario.yml")
-    lockdir="/tmp/varnish-purge-acl-test-8085.lock"
-        project="varnish-purge-acl-$$"
-        HOSTILE_SCENARIO_PORT=8085
-        HOSTILE_SCENARIO_SUBNET=203.0.113.0/24
-        HOSTILE_SCENARIO_VARNISH_IP=203.0.113.2
-    readiness_url="http://localhost:8085/ready"
-    assertion_script="$repo_root/test/e2e/assert-hostile-purge-acl.sh"
-    services=()
-    curl_max_time=5
-    ;;
-	*)
-		echo "Unknown hostile scenario: $scenario" >&2
-		exit 1
-		;;
-esac
+if [ -z "$scenario" ]; then
+  usage
+  exit 1
+fi
+
+if [ "$scenario" = "--describe" ]; then
+  scenario="${2:-}"
+  if [ -z "$scenario" ]; then
+    usage
+    exit 1
+  fi
+  describe_scenario
+  exit 0
+fi
+
+configure_scenario
 
 export HOSTILE_SCENARIO_PORT="${HOSTILE_SCENARIO_PORT:-}"
 export HOSTILE_SCENARIO_SUBNET="${HOSTILE_SCENARIO_SUBNET:-}"
@@ -137,30 +174,30 @@ export COMPOSE_PROJECT_NAME="$project"
 trap cleanup EXIT
 
 while ! mkdir "$lockdir" 2>/dev/null; do
-	sleep 1
+  sleep 1
 done
 
 tmpdir="$(mktemp -d)"
 
 if [ -n "${HOSTILE_SCENARIO_SUBNET:-}" ]; then
-    purge_override="$tmpdir/docker-compose.purge-acl.override.yml"
-    cat >"$purge_override" <<EOF
+  purge_override="$tmpdir/docker-compose.purge-acl.override.yml"
+  cat >"$purge_override" <<EOF
 services:
   varnish:
     networks:
       backend:
       external:
-        ipv4_address: ${HOSTILE_SCENARIO_VARNISH_IP:?HOSTILE_SCENARIO_VARNISH_IP is required}
+        ipv4_address: ${HOSTILE_SCENARIO_VARNISH_IP:?HOSTILE_SCENARIO_VARNISH_IP required}
 
 networks:
   external:
     ipam:
       driver: default
       config:
-        - subnet: ${HOSTILE_SCENARIO_SUBNET:?HOSTILE_SCENARIO_SUBNET is required}
+        - subnet: ${HOSTILE_SCENARIO_SUBNET:?HOSTILE_SCENARIO_SUBNET required}
 EOF
-    compose_files+=("$purge_override")
-    COMPOSE_FILE="$(IFS=:; echo "${compose_files[*]}")"
+  compose_files+=("$purge_override")
+  COMPOSE_FILE="$(IFS=:; echo "${compose_files[*]}")"
 fi
 
 if [ "${#services[@]}" -gt 0 ]; then
@@ -169,9 +206,9 @@ else
   compose up -d --build
 fi
 
-echo "Waiting hostile services to be ready..."
+echo "Waiting hostile services be ready..."
 if ! wait_for_ready "$ready_timeout" "$readiness_url" "OK: Hostile services ready"; then
-  echo "FAIL: Hostile services did not become ready within 60s"
+  echo "FAIL: Hostile services did not become ready within ${ready_timeout}s"
   compose logs
   exit 1
 fi


### PR DESCRIPTION
## Summary
- refactor hostile E2E runner around shared scenario configuration helpers
- add a fast harness canary for scenario metadata and useful unknown-scenario failures
- run the harness canary from both the hard E2E suite and the main test target

Closes #10

## Verification
- make test-e2e-harness-module
- make test-e2e-hard
- make test